### PR TITLE
Add moveable events in the most simple way. Enough to use as triggers…

### DIFF
--- a/nodes/locales/en-US/ui-tabulator.html
+++ b/nodes/locales/en-US/ui-tabulator.html
@@ -299,7 +299,7 @@ For example:
 <p><i><b>Supported Events</b></i>
 <ul>
 <li><b>Table Creation</b><pre><code>tableBuilt, tableDestroyed</code></pre></li>
-<li><b>Row Interaction</b><pre><code>rowClick, rowDblClick, rowTap, rowDblTap, rowTapHold, rowSelected, rowDeselected</code></pre></li>
+<li><b>Row Interaction</b><pre><code>rowClick, rowDblClick, rowTap, rowDblTap, rowTapHold, rowSelected, rowDeselected, rowMove, rowMoved, rowMoveCancelled</code></pre></li>
 <li><b>Cell Interaction</b><pre><code>cellClick, cellDblClick, cellTap, cellDblTap, cellTapHold</code></pre></li>
 <li><b>Cell Change (by user in-cell editing) </b><pre><code>cellEdited</code></pre></li>
 <li><b>Data Change</b><pre><code>rowAdded, rowUpdated, rowDeleted, dataChanged</code></pre></li>

--- a/nodes/locales/en-US/ui-tabulator.html
+++ b/nodes/locales/en-US/ui-tabulator.html
@@ -299,7 +299,7 @@ For example:
 <p><i><b>Supported Events</b></i>
 <ul>
 <li><b>Table Creation</b><pre><code>tableBuilt, tableDestroyed</code></pre></li>
-<li><b>Row Interaction</b><pre><code>rowClick, rowDblClick, rowTap, rowDblTap, rowTapHold, rowSelected, rowDeselected, rowMove, rowMoved, rowMoveCancelled</code></pre></li>
+<li><b>Row Interaction</b><pre><code>rowClick, rowDblClick, rowTap, rowDblTap, rowTapHold, rowSelected, rowDeselected, rowMoving, rowMoved, rowMoveCancelled</code></pre></li>
 <li><b>Cell Interaction</b><pre><code>cellClick, cellDblClick, cellTap, cellDblTap, cellTapHold</code></pre></li>
 <li><b>Cell Change (by user in-cell editing) </b><pre><code>cellEdited</code></pre></li>
 <li><b>Data Change</b><pre><code>rowAdded, rowUpdated, rowDeleted, dataChanged</code></pre></li>

--- a/ui/components/UITabulator.vue
+++ b/ui/components/UITabulator.vue
@@ -1201,7 +1201,7 @@ function setEventNotifications($widgetScope)
 		//-------------------------------------------------------
 		// Row events
 		//-------------------------------------------------------
-			case "rowMove":
+			case "rowMoving":
 			case "rowMoveCancelled":
 			case "rowMoved":
 			case "rowClick":

--- a/ui/components/UITabulator.vue
+++ b/ui/components/UITabulator.vue
@@ -1201,6 +1201,9 @@ function setEventNotifications($widgetScope)
 		//-------------------------------------------------------
 		// Row events
 		//-------------------------------------------------------
+			case "rowMove":
+			case "rowMoveCancelled":
+			case "rowMoved":
 			case "rowClick":
 			case "rowDblClick":
 			case "rowTap":


### PR DESCRIPTION
… for other actions.

It would be nice if Tabulator provided more data with rowMove event - but I don't think it does.

`		this.dispatchExternal("rowMoved", from.getComponent());`

Seems to only send the row that was moved - not its start or end point.